### PR TITLE
feat: ThemeProviderパターンで全画面ダークモード対応

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,21 +1,41 @@
 import { StatusBar } from 'expo-status-bar';
 import { useEffect } from 'react';
 import { AppNavigator } from './src/navigation/AppNavigator';
+import { ThemeProvider, useTheme } from './src/theme';
 import { useSettingsStore } from './src/stores/settingsStore';
 
-export default function App() {
-  const { settings, loadSettings } = useSettingsStore();
+/**
+ * StatusBar コンポーネント
+ * テーマに応じてスタイルを切り替える
+ */
+const ThemedStatusBar = () => {
+  const { isDarkMode } = useTheme();
+  return <StatusBar style={isDarkMode ? 'light' : 'dark'} />;
+};
+
+/**
+ * アプリ初期化コンポーネント
+ * 設定をロードしてから子コンポーネントを表示
+ */
+const AppContent = () => {
+  const loadSettings = useSettingsStore((state) => state.loadSettings);
 
   useEffect(() => {
     loadSettings();
-  }, []);
-
-  const statusBarStyle = settings.isDarkMode ? 'light' : 'auto';
+  }, [loadSettings]);
 
   return (
     <>
       <AppNavigator />
-      <StatusBar style={statusBarStyle} />
+      <ThemedStatusBar />
     </>
+  );
+};
+
+export default function App() {
+  return (
+    <ThemeProvider>
+      <AppContent />
+    </ThemeProvider>
   );
 }

--- a/__tests__/components/Card.test.tsx
+++ b/__tests__/components/Card.test.tsx
@@ -5,6 +5,44 @@ import React from 'react';
 import { Text, StyleSheet, Platform } from 'react-native';
 import { render, fireEvent } from '@testing-library/react-native';
 import { Card } from '../../src/components/Card';
+import { LIGHT_THEME } from '../../src/theme';
+
+// テーマをモック
+jest.mock('../../src/theme', () => ({
+  useThemeColors: jest.fn(() => ({
+    background: '#F5F5F5',
+    cardBackground: '#FFFFFF',
+    text: '#000000',
+    textSecondary: '#666666',
+    border: '#E0E0E0',
+    primary: '#007AFF',
+    error: '#FF3B30',
+    white: '#FFFFFF',
+    selected: '#E3F2FD',
+  })),
+  LIGHT_THEME: {
+    background: '#F5F5F5',
+    cardBackground: '#FFFFFF',
+    text: '#000000',
+    textSecondary: '#666666',
+    border: '#E0E0E0',
+    primary: '#007AFF',
+    error: '#FF3B30',
+    white: '#FFFFFF',
+    selected: '#E3F2FD',
+  },
+  DARK_THEME: {
+    background: '#1A1A1A',
+    cardBackground: '#2A2A2A',
+    text: '#FFFFFF',
+    textSecondary: '#AAAAAA',
+    border: '#3A3A3A',
+    primary: '#0A84FF',
+    error: '#FF453A',
+    white: '#1A1A1A',
+    selected: '#1E3A5F',
+  },
+}));
 
 describe('Card', () => {
   it('子要素を正しくレンダリングする', () => {
@@ -43,7 +81,7 @@ describe('Card', () => {
     const style = StyleSheet.flatten(card.props.style);
 
     expect(style.borderWidth).toBe(1);
-    expect(style.borderColor).toBe('#CCCCCC');
+    expect(style.borderColor).toBe(LIGHT_THEME.border);
     // Viewとしてレンダリングされる（onPressなし）
     expect(card.type).toBe('View');
   });
@@ -190,7 +228,7 @@ describe('Card', () => {
 
       // defaultスタイル（枠線）が適用される
       expect(style.borderWidth).toBe(1);
-      expect(style.borderColor).toBe('#CCCCCC');
+      expect(style.borderColor).toBe(LIGHT_THEME.border);
     });
 
     it('childrenが空でもレンダリングできる', () => {

--- a/__tests__/components/ListItem.test.tsx
+++ b/__tests__/components/ListItem.test.tsx
@@ -5,6 +5,44 @@ import React from 'react';
 import { StyleSheet } from 'react-native';
 import { render, fireEvent } from '@testing-library/react-native';
 import { ListItem } from '../../src/components/ListItem';
+import { LIGHT_THEME } from '../../src/theme';
+
+// テーマをモック
+jest.mock('../../src/theme', () => ({
+  useThemeColors: jest.fn(() => ({
+    background: '#F5F5F5',
+    cardBackground: '#FFFFFF',
+    text: '#000000',
+    textSecondary: '#666666',
+    border: '#E0E0E0',
+    primary: '#007AFF',
+    error: '#FF3B30',
+    white: '#FFFFFF',
+    selected: '#E3F2FD',
+  })),
+  LIGHT_THEME: {
+    background: '#F5F5F5',
+    cardBackground: '#FFFFFF',
+    text: '#000000',
+    textSecondary: '#666666',
+    border: '#E0E0E0',
+    primary: '#007AFF',
+    error: '#FF3B30',
+    white: '#FFFFFF',
+    selected: '#E3F2FD',
+  },
+  DARK_THEME: {
+    background: '#1A1A1A',
+    cardBackground: '#2A2A2A',
+    text: '#FFFFFF',
+    textSecondary: '#AAAAAA',
+    border: '#3A3A3A',
+    primary: '#0A84FF',
+    error: '#FF453A',
+    white: '#1A1A1A',
+    selected: '#1E3A5F',
+  },
+}));
 
 describe('ListItem', () => {
   it('titleを表示する', () => {
@@ -90,7 +128,7 @@ describe('ListItem', () => {
     const style = StyleSheet.flatten(arrowElement.props.style);
 
     expect(style.fontSize).toBe(20);
-    expect(style.color).toBe('#999999');
+    expect(style.color).toBe(LIGHT_THEME.textSecondary);
   });
 
   it('右矢印を非表示にする（showArrow=false時）', () => {

--- a/__tests__/screens/DisplaySettingsScreen.test.tsx
+++ b/__tests__/screens/DisplaySettingsScreen.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { StyleSheet } from 'react-native';
 import { DisplaySettingsScreen } from '../../src/screens/DisplaySettingsScreen';
-import { LIGHT_THEME, DARK_THEME } from '../../src/utils/theme';
+import { LIGHT_THEME, DARK_THEME } from '../../src/theme';
 
 const mockSetDarkMode = jest.fn().mockResolvedValue(undefined);
 const mockLoadSettings = jest.fn().mockResolvedValue(undefined);
@@ -14,7 +14,7 @@ jest.mock('../../src/stores/settingsStore', () => ({
   useSettingsStore: jest.fn(),
 }));
 
-jest.mock('../../src/utils/theme', () => ({
+jest.mock('../../src/theme', () => ({
   LIGHT_THEME: {
     background: '#F5F5F5',
     cardBackground: '#FFFFFF',
@@ -23,6 +23,8 @@ jest.mock('../../src/utils/theme', () => ({
     border: '#E0E0E0',
     primary: '#007AFF',
     error: '#FF3B30',
+    white: '#FFFFFF',
+    selected: '#E3F2FD',
   },
   DARK_THEME: {
     background: '#1A1A1A',
@@ -32,17 +34,21 @@ jest.mock('../../src/utils/theme', () => ({
     border: '#3A3A3A',
     primary: '#0A84FF',
     error: '#FF453A',
+    white: '#1A1A1A',
+    selected: '#1E3A5F',
   },
+  useThemeColors: jest.fn(),
   useTheme: jest.fn(),
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
 import { useSettingsStore } from '../../src/stores/settingsStore';
-import { useTheme } from '../../src/utils/theme';
+import { useThemeColors } from '../../src/theme';
 
 const mockUseSettingsStore = useSettingsStore as jest.MockedFunction<
   typeof useSettingsStore
 >;
-const mockUseTheme = useTheme as jest.MockedFunction<typeof useTheme>;
+const mockUseThemeColors = useThemeColors as jest.MockedFunction<typeof useThemeColors>;
 
 const createMockStore = (overrides: Partial<{
   settings: { isDarkMode: boolean };
@@ -59,7 +65,7 @@ describe('DisplaySettingsScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockUseSettingsStore.mockReturnValue(createMockStore() as any);
-    mockUseTheme.mockReturnValue(LIGHT_THEME);
+    mockUseThemeColors.mockReturnValue(LIGHT_THEME);
   });
 
   describe('仕様検証', () => {
@@ -181,7 +187,7 @@ describe('DisplaySettingsScreen', () => {
       mockUseSettingsStore.mockReturnValue(
         createMockStore({ settings: { isDarkMode: true } }) as any
       );
-      mockUseTheme.mockReturnValue(DARK_THEME);
+      mockUseThemeColors.mockReturnValue(DARK_THEME);
       const { getByText } = render(<DisplaySettingsScreen />);
       const style = StyleSheet.flatten(getByText('表示設定').props.style);
       expect(style.color).toBe(DARK_THEME.text);
@@ -191,7 +197,7 @@ describe('DisplaySettingsScreen', () => {
       mockUseSettingsStore.mockReturnValue(
         createMockStore({ settings: { isDarkMode: true } }) as any
       );
-      mockUseTheme.mockReturnValue(DARK_THEME);
+      mockUseThemeColors.mockReturnValue(DARK_THEME);
       const { getByTestId } = render(<DisplaySettingsScreen />);
       const style = StyleSheet.flatten(
         getByTestId('display-settings-screen').props.style

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -11,6 +11,7 @@ import {
   TextStyle,
   PressableProps,
 } from 'react-native';
+import { useThemeColors, ThemeColors } from '../theme';
 
 export interface ButtonProps {
   title: string;
@@ -29,6 +30,8 @@ export const Button: React.FC<ButtonProps> = ({
   loading = false,
   testID,
 }) => {
+  const theme = useThemeColors();
+  const styles = createStyles(theme);
   const isDisabled = disabled || loading;
 
   const handlePress = () => {
@@ -49,6 +52,9 @@ export const Button: React.FC<ButtonProps> = ({
     isDisabled && styles.text_disabled,
   ].filter(Boolean) as TextStyle[];
 
+  // ActivityIndicatorの色: outline → primary, それ以外 → white
+  const indicatorColor = variant === 'outline' ? theme.primary : theme.white;
+
   return (
     <Pressable
       style={buttonStyle}
@@ -59,9 +65,7 @@ export const Button: React.FC<ButtonProps> = ({
       testID={testID}
     >
       {loading ? (
-        <ActivityIndicator
-          color={variant === 'outline' ? '#007AFF' : '#FFFFFF'}
-        />
+        <ActivityIndicator color={indicatorColor} />
       ) : (
         <Text style={textStyle}>{title}</Text>
       )}
@@ -69,7 +73,7 @@ export const Button: React.FC<ButtonProps> = ({
   );
 };
 
-const styles = StyleSheet.create({
+const createStyles = (theme: ThemeColors) => StyleSheet.create({
   button: {
     paddingVertical: 12,
     paddingHorizontal: 24,
@@ -77,35 +81,35 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     minHeight: 48,
-  },
+  } as ViewStyle,
   button_primary: {
-    backgroundColor: '#007AFF',
-  },
+    backgroundColor: theme.primary,
+  } as ViewStyle,
   button_secondary: {
-    backgroundColor: '#8E8E93',
-  },
+    backgroundColor: '#8E8E93', // gray - テーマに依存しない固定色
+  } as ViewStyle,
   button_outline: {
     backgroundColor: 'transparent',
     borderWidth: 1,
-    borderColor: '#007AFF',
-  },
+    borderColor: theme.primary,
+  } as ViewStyle,
   button_disabled: {
     opacity: 0.5,
-  },
+  } as ViewStyle,
   text: {
     fontSize: 16,
     fontWeight: '600',
-  },
+  } as TextStyle,
   text_primary: {
-    color: '#FFFFFF',
-  },
+    color: theme.white,
+  } as TextStyle,
   text_secondary: {
-    color: '#FFFFFF',
-  },
+    color: theme.white,
+  } as TextStyle,
   text_outline: {
-    color: '#007AFF',
-  },
+    color: theme.primary,
+  } as TextStyle,
   text_disabled: {
     opacity: 1, // 親のopacityで制御されるため
-  },
+  } as TextStyle,
 });

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -10,14 +10,7 @@ import {
   ViewStyle,
   Platform,
 } from 'react-native';
-
-// カラー定数
-const COLORS = {
-  background: '#FFFFFF',
-  border: '#CCCCCC',
-  pressed: '#F0F0F0',
-  shadow: '#000000',
-};
+import { useThemeColors, ThemeColors } from '../theme';
 
 export interface CardProps {
   children: React.ReactNode;       // カード内のコンテンツ
@@ -38,6 +31,8 @@ export const Card: React.FC<CardProps> = ({
   testID,
   accessibilityLabel,
 }) => {
+  const theme = useThemeColors();
+  const styles = createStyles(theme);
   const isDisabled = disabled;
 
   const handlePress = () => {
@@ -86,10 +81,15 @@ export const Card: React.FC<CardProps> = ({
   );
 };
 
+const BORDER_RADIUS = 8;
+const PADDING = 16;
+const BORDER_WIDTH = 1;
+const DISABLED_OPACITY = 0.5;
+
 // クロスプラットフォーム対応のshadow/elevation
-const ELEVATION_STYLES = Platform.select({
+const createElevationStyles = (theme: ThemeColors) => Platform.select({
   ios: {
-    shadowColor: COLORS.shadow,
+    shadowColor: theme.text,
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.1,
     shadowRadius: 4,
@@ -100,28 +100,26 @@ const ELEVATION_STYLES = Platform.select({
   default: {},
 });
 
-const BORDER_RADIUS = 8;
-const PADDING = 16;
-const BORDER_WIDTH = 1;
-const DISABLED_OPACITY = 0.5;
-
-const styles = StyleSheet.create({
-  card: {
-    backgroundColor: COLORS.background,
-    borderRadius: BORDER_RADIUS,
-    padding: PADDING,
-  },
-  card_default: {
-    borderWidth: BORDER_WIDTH,
-    borderColor: COLORS.border,
-  },
-  card_elevated: {
-    ...ELEVATION_STYLES,
-  },
-  card_pressed: {
-    backgroundColor: COLORS.pressed,
-  },
-  card_disabled: {
-    opacity: DISABLED_OPACITY,
-  },
-});
+const createStyles = (theme: ThemeColors) => {
+  const elevationStyles = createElevationStyles(theme);
+  return StyleSheet.create({
+    card: {
+      backgroundColor: theme.cardBackground,
+      borderRadius: BORDER_RADIUS,
+      padding: PADDING,
+    } as ViewStyle,
+    card_default: {
+      borderWidth: BORDER_WIDTH,
+      borderColor: theme.border,
+    } as ViewStyle,
+    card_elevated: {
+      ...elevationStyles,
+    } as ViewStyle,
+    card_pressed: {
+      backgroundColor: theme.selected,
+    } as ViewStyle,
+    card_disabled: {
+      opacity: DISABLED_OPACITY,
+    } as ViewStyle,
+  });
+};

--- a/src/components/ListItem.tsx
+++ b/src/components/ListItem.tsx
@@ -11,16 +11,7 @@ import {
   ViewStyle,
   TextStyle,
 } from 'react-native';
-
-// カラー定数
-const COLORS = {
-  background: '#FFFFFF',
-  pressed: '#F0F0F0',
-  border: '#E0E0E0',
-  title: '#000000',
-  subtitle: '#666666',
-  arrow: '#999999',
-};
+import { useThemeColors, ThemeColors } from '../theme';
 
 export interface ListItemProps {
   title: string;                // メインテキスト（必須）
@@ -41,6 +32,8 @@ export const ListItem: React.FC<ListItemProps> = ({
   testID,
   accessibilityLabel = title,
 }) => {
+  const theme = useThemeColors();
+  const styles = createStyles(theme);
   const isDisabled = disabled;
 
   const handlePress = () => {
@@ -88,42 +81,42 @@ const SUBTITLE_FONT_SIZE = 14;
 const ARROW_FONT_SIZE = 20;
 const DISABLED_OPACITY = 0.5;
 
-const styles = StyleSheet.create({
+const createStyles = (theme: ThemeColors) => StyleSheet.create({
   container: {
     minHeight: MIN_HEIGHT,
     paddingHorizontal: PADDING_HORIZONTAL,
     paddingVertical: PADDING_VERTICAL,
-    backgroundColor: COLORS.background,
+    backgroundColor: theme.cardBackground,
     borderBottomWidth: 1,
-    borderBottomColor: COLORS.border,
-  },
+    borderBottomColor: theme.border,
+  } as ViewStyle,
   container_disabled: {
     opacity: DISABLED_OPACITY,
-  },
+  } as ViewStyle,
   container_pressed: {
-    backgroundColor: COLORS.pressed,
-  },
+    backgroundColor: theme.selected,
+  } as ViewStyle,
   content: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-  },
+  } as ViewStyle,
   textContainer: {
     flex: 1,
-  },
+  } as ViewStyle,
   title: {
     fontSize: TITLE_FONT_SIZE,
     fontWeight: '600',
-    color: COLORS.title,
+    color: theme.text,
     marginBottom: 4,
-  },
+  } as TextStyle,
   subtitle: {
     fontSize: SUBTITLE_FONT_SIZE,
-    color: COLORS.subtitle,
-  },
+    color: theme.textSecondary,
+  } as TextStyle,
   arrow: {
     fontSize: ARROW_FONT_SIZE,
-    color: COLORS.arrow,
+    color: theme.textSecondary,
     marginLeft: 8,
-  },
+  } as TextStyle,
 });

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -10,14 +10,7 @@ import {
   TextStyle,
   ViewStyle,
 } from 'react-native';
-
-// 定数
-const COLORS = {
-  text: '#000',
-  border: '#ccc',
-  error: '#FF3B30',
-  placeholder: '#999',
-} as const;
+import { useThemeColors, ThemeColors } from '../theme';
 
 const FONT_SIZES = {
   label: 14,
@@ -48,6 +41,9 @@ export const TextInput: React.FC<TextInputProps> = ({
   testID,
   accessibilityLabel,
 }) => {
+  const theme = useThemeColors();
+  const styles = createStyles(theme);
+
   const inputStyle: TextStyle[] = [
     styles.input,
     error && styles.inputError,
@@ -68,7 +64,7 @@ export const TextInput: React.FC<TextInputProps> = ({
         multiline={multiline}
         editable={editable}
         testID={testID || 'text-input'}
-        placeholderTextColor={COLORS.placeholder}
+        placeholderTextColor={theme.textSecondary}
         accessibilityLabel={accessibilityLabel || label}
         accessibilityState={{ disabled: !editable }}
         accessibilityHint={error}
@@ -86,7 +82,7 @@ export const TextInput: React.FC<TextInputProps> = ({
   );
 };
 
-const styles = StyleSheet.create({
+const createStyles = (theme: ThemeColors) => StyleSheet.create({
   container: {
     marginBottom: 16,
   } as ViewStyle,
@@ -94,24 +90,24 @@ const styles = StyleSheet.create({
     fontSize: FONT_SIZES.label,
     fontWeight: '600',
     marginBottom: 8,
-    color: COLORS.text,
+    color: theme.text,
   } as TextStyle,
   input: {
     borderWidth: 1,
-    borderColor: COLORS.border,
+    borderColor: theme.border,
     borderRadius: 8,
     paddingHorizontal: 12,
     paddingVertical: 10,
     fontSize: FONT_SIZES.input,
-    color: COLORS.text,
+    color: theme.text,
     minHeight: 44,
   } as TextStyle,
   inputError: {
-    borderColor: COLORS.error,
+    borderColor: theme.error,
   } as ViewStyle,
   error: {
     fontSize: FONT_SIZES.error,
-    color: COLORS.error,
+    color: theme.error,
     marginTop: 4,
   } as TextStyle,
 });

--- a/src/components/VoiceInputButton.tsx
+++ b/src/components/VoiceInputButton.tsx
@@ -9,13 +9,9 @@ import {
   StyleSheet,
   Animated,
   ViewStyle,
+  TextStyle,
 } from 'react-native';
-
-// カラー定数
-const COLORS = {
-  primary: '#007AFF',      // iOS Blue
-  recording: '#FF3B30',    // Red
-};
+import { useThemeColors, ThemeColors } from '../theme';
 
 export interface VoiceInputButtonProps {
   onPress: () => void;           // タップ時のコールバック
@@ -32,6 +28,8 @@ export const VoiceInputButton: React.FC<VoiceInputButtonProps> = ({
   testID,
   accessibilityLabel = '音声入力',
 }) => {
+  const theme = useThemeColors();
+  const styles = createStyles(theme);
   const pulseAnim = useRef(new Animated.Value(1)).current;
 
   useEffect(() => {
@@ -109,22 +107,22 @@ const BUTTON_SIZE = 56;
 const ICON_SIZE = 24;
 const DISABLED_OPACITY = 0.5;
 
-const styles = StyleSheet.create({
+const createStyles = (theme: ThemeColors) => StyleSheet.create({
   button: {
     width: BUTTON_SIZE,
     height: BUTTON_SIZE,
     borderRadius: BUTTON_SIZE / 2,
-    backgroundColor: COLORS.primary,
+    backgroundColor: theme.primary,
     alignItems: 'center',
     justifyContent: 'center',
-  },
+  } as ViewStyle,
   button_recording: {
-    backgroundColor: COLORS.recording,
-  },
+    backgroundColor: theme.error,
+  } as ViewStyle,
   button_disabled: {
     opacity: DISABLED_OPACITY,
-  },
+  } as ViewStyle,
   icon: {
     fontSize: ICON_SIZE,
-  },
+  } as TextStyle,
 });

--- a/src/screens/DataManagementScreen.tsx
+++ b/src/screens/DataManagementScreen.tsx
@@ -16,17 +16,7 @@ import {
 } from 'react-native';
 import { useDiaryStore } from '../stores/diaryStore';
 import { ExportService } from '../services/export';
-
-// カラー定数
-const COLORS = {
-  background: '#F5F5F5',
-  text: '#000000',
-  textSecondary: '#666666',
-  error: '#FF3B30',
-  danger: '#FF3B30',
-  buttonBackground: '#FFFFFF',
-  buttonBorder: '#E0E0E0',
-};
+import { useThemeColors, ThemeColors } from '../theme';
 
 // フォントサイズ定数
 const FONT_SIZES = {
@@ -45,6 +35,8 @@ const SPACING = {
 
 export const DataManagementScreen: React.FC = () => {
   const { entries, deleteEntry } = useDiaryStore();
+  const theme = useThemeColors();
+  const styles = createStyles(theme);
   const [isLoading, setIsLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
@@ -161,7 +153,7 @@ export const DataManagementScreen: React.FC = () => {
         <ActivityIndicator
           testID="loading-indicator"
           size="large"
-          color={COLORS.text}
+          color={theme.text}
           style={styles.loading}
         />
       )}
@@ -176,10 +168,10 @@ export const DataManagementScreen: React.FC = () => {
   );
 };
 
-const styles = StyleSheet.create({
+const createStyles = (theme: ThemeColors) => StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: COLORS.background,
+    backgroundColor: theme.background,
   } as ViewStyle,
   contentContainer: {
     padding: SPACING.container,
@@ -187,7 +179,7 @@ const styles = StyleSheet.create({
   title: {
     fontSize: FONT_SIZES.title,
     fontWeight: '600',
-    color: COLORS.text,
+    color: theme.text,
     marginBottom: SPACING.titleBottom,
   } as TextStyle,
   section: {
@@ -196,13 +188,13 @@ const styles = StyleSheet.create({
   sectionTitle: {
     fontSize: FONT_SIZES.body,
     fontWeight: '600',
-    color: COLORS.textSecondary,
+    color: theme.textSecondary,
     marginBottom: SPACING.itemGap,
   } as TextStyle,
   button: {
-    backgroundColor: COLORS.buttonBackground,
+    backgroundColor: theme.cardBackground,
     borderWidth: 1,
-    borderColor: COLORS.buttonBorder,
+    borderColor: theme.border,
     borderRadius: 8,
     padding: SPACING.container,
     marginBottom: SPACING.itemGap,
@@ -210,13 +202,13 @@ const styles = StyleSheet.create({
   } as ViewStyle,
   buttonText: {
     fontSize: FONT_SIZES.body,
-    color: COLORS.text,
+    color: theme.text,
     fontWeight: '500',
   } as TextStyle,
   dangerButton: {
-    backgroundColor: COLORS.buttonBackground,
+    backgroundColor: theme.cardBackground,
     borderWidth: 1,
-    borderColor: COLORS.danger,
+    borderColor: theme.error,
     borderRadius: 8,
     padding: SPACING.container,
     marginBottom: SPACING.itemGap,
@@ -224,7 +216,7 @@ const styles = StyleSheet.create({
   } as ViewStyle,
   dangerButtonText: {
     fontSize: FONT_SIZES.body,
-    color: COLORS.danger,
+    color: theme.error,
     fontWeight: '500',
   } as TextStyle,
   loading: {
@@ -232,7 +224,7 @@ const styles = StyleSheet.create({
   } as ViewStyle,
   errorText: {
     fontSize: FONT_SIZES.caption,
-    color: COLORS.error,
+    color: theme.error,
     marginTop: SPACING.itemGap,
     textAlign: 'center',
   } as TextStyle,

--- a/src/screens/DiaryDetailScreen.tsx
+++ b/src/screens/DiaryDetailScreen.tsx
@@ -24,14 +24,7 @@ import { Button } from '../components/Button';
 import { TextInput } from '../components/TextInput';
 import { Card } from '../components/Card';
 import { DiaryAnswer, DiaryEntry } from '../types';
-
-// カラー定数
-const COLORS = {
-  background: '#F5F5F5',
-  text: '#000000',
-  textSecondary: '#666666',
-  error: '#FF3B30',
-};
+import { useThemeColors, ThemeColors } from '../theme';
 
 // フォントサイズ定数
 const FONT_SIZES = {
@@ -54,6 +47,8 @@ export const DiaryDetailScreen: React.FC = () => {
   const navigation = useNavigation();
   const { entryId } = route.params;
   const { getEntryById, updateEntry, deleteEntry } = useDiaryStore();
+  const theme = useThemeColors();
+  const styles = createStyles(theme);
 
   const [isEditing, setIsEditing] = useState(false);
   const [editedAnswers, setEditedAnswers] = useState<{
@@ -214,10 +209,10 @@ export const DiaryDetailScreen: React.FC = () => {
   );
 };
 
-const styles = StyleSheet.create({
+const createStyles = (theme: ThemeColors) => StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: COLORS.background,
+    backgroundColor: theme.background,
   } as ViewStyle,
   contentContainer: {
     padding: SPACING.container,
@@ -225,7 +220,7 @@ const styles = StyleSheet.create({
   date: {
     fontSize: FONT_SIZES.date,
     fontWeight: '600',
-    color: COLORS.text,
+    color: theme.text,
     marginBottom: SPACING.dateBottom,
   } as TextStyle,
   answerCard: {
@@ -234,12 +229,12 @@ const styles = StyleSheet.create({
   questionText: {
     fontSize: FONT_SIZES.question,
     fontWeight: '600',
-    color: COLORS.text,
+    color: theme.text,
     marginBottom: 8,
   } as TextStyle,
   answerText: {
     fontSize: FONT_SIZES.answer,
-    color: COLORS.textSecondary,
+    color: theme.textSecondary,
   } as TextStyle,
   buttonContainer: {
     flexDirection: 'row',
@@ -249,7 +244,7 @@ const styles = StyleSheet.create({
   } as ViewStyle,
   errorText: {
     fontSize: FONT_SIZES.body,
-    color: COLORS.error,
+    color: theme.error,
     textAlign: 'center',
     marginTop: 20,
   } as TextStyle,

--- a/src/screens/DiaryInputScreen.tsx
+++ b/src/screens/DiaryInputScreen.tsx
@@ -25,17 +25,7 @@ import type { RootStackParamList } from '../types/navigation';
 import { Button } from '../components/Button';
 import { TextInput } from '../components/TextInput';
 import { DiaryEntry, DiaryAnswer } from '../types';
-
-// カラー定数
-const COLORS = {
-  background: '#F5F5F5',
-  white: '#FFFFFF',
-  text: '#000000',
-  textSecondary: '#666666',
-  error: '#FF3B30',
-  primary: '#007AFF',
-  selected: '#E3F2FD',
-};
+import { useThemeColors, ThemeColors } from '../theme';
 
 // フォントサイズ定数
 const FONT_SIZES = {
@@ -58,6 +48,8 @@ type DiaryInputNavigationProp = NativeStackNavigationProp<RootStackParamList, 'D
 
 export const DiaryInputScreen: React.FC = () => {
   const navigation = useNavigation<DiaryInputNavigationProp>();
+  const theme = useThemeColors();
+  const styles = createStyles(theme);
   const { questions, isLoading, error, loadQuestions, getActiveQuestions } =
     useQuestionStore();
   const { addEntry } = useDiaryStore();
@@ -239,10 +231,10 @@ export const DiaryInputScreen: React.FC = () => {
   );
 };
 
-const styles = StyleSheet.create({
+const createStyles = (theme: ThemeColors) => StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: COLORS.background,
+    backgroundColor: theme.background,
   } as ViewStyle,
   contentContainer: {
     padding: SPACING.container,
@@ -250,18 +242,18 @@ const styles = StyleSheet.create({
   title: {
     fontSize: FONT_SIZES.title,
     fontWeight: '600',
-    color: COLORS.text,
+    color: theme.text,
     marginBottom: SPACING.questionBottom,
   } as TextStyle,
   progress: {
     fontSize: FONT_SIZES.progress,
-    color: COLORS.textSecondary,
+    color: theme.textSecondary,
     marginBottom: SPACING.progressBottom,
   } as TextStyle,
   question: {
     fontSize: FONT_SIZES.question,
     fontWeight: '600',
-    color: COLORS.text,
+    color: theme.text,
     marginBottom: SPACING.questionBottom,
   } as TextStyle,
   ratingContainer: {
@@ -277,13 +269,13 @@ const styles = StyleSheet.create({
   } as ViewStyle,
   loadingText: {
     fontSize: FONT_SIZES.body,
-    color: COLORS.textSecondary,
+    color: theme.textSecondary,
     textAlign: 'center',
     marginTop: 20,
   } as TextStyle,
   errorText: {
     fontSize: FONT_SIZES.body,
-    color: COLORS.error,
+    color: theme.error,
     textAlign: 'center',
     marginTop: 20,
   } as TextStyle,

--- a/src/screens/DisplaySettingsScreen.tsx
+++ b/src/screens/DisplaySettingsScreen.tsx
@@ -5,7 +5,7 @@
 import React, { useEffect } from 'react';
 import { View, Text, Switch, StyleSheet, ViewStyle, TextStyle } from 'react-native';
 import { useSettingsStore } from '../stores/settingsStore';
-import { useTheme } from '../utils/theme';
+import { useThemeColors, ThemeColors } from '../theme';
 
 const FONT_SIZES = {
   title: 24,
@@ -21,7 +21,7 @@ const SPACING = {
 
 export const DisplaySettingsScreen: React.FC = () => {
   const { settings, loadSettings, setDarkMode } = useSettingsStore();
-  const theme = useTheme();
+  const theme = useThemeColors();
 
   useEffect(() => {
     loadSettings();
@@ -48,7 +48,7 @@ export const DisplaySettingsScreen: React.FC = () => {
   );
 };
 
-const createStyles = (theme: ReturnType<typeof useTheme>) => {
+const createStyles = (theme: ThemeColors) => {
   return StyleSheet.create({
     container: {
       flex: 1,

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -23,7 +23,7 @@ import { Button } from '../components/Button';
 import { ListItem } from '../components/ListItem';
 import { DiaryEntry } from '../types';
 import type { RootStackParamList } from '../types/navigation';
-import { useTheme } from '../utils/theme';
+import { useThemeColors, ThemeColors } from '../theme';
 
 type HomeScreenNavigationProp = NativeStackNavigationProp<RootStackParamList, 'Home'>;
 
@@ -53,7 +53,7 @@ export const HomeScreen: React.FC = () => {
     loadEntries,
     getEntryByDate,
   } = useDiaryStore();
-  const theme = useTheme();
+  const theme = useThemeColors();
   const styles = createStyles(theme);
 
   useEffect(() => {
@@ -145,7 +145,7 @@ export const HomeScreen: React.FC = () => {
   );
 };
 
-const createStyles = (theme: ReturnType<typeof useTheme>) => StyleSheet.create({
+const createStyles = (theme: ThemeColors) => StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: theme.background,

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -23,17 +23,9 @@ import { Button } from '../components/Button';
 import { ListItem } from '../components/ListItem';
 import { DiaryEntry } from '../types';
 import type { RootStackParamList } from '../types/navigation';
+import { useTheme } from '../utils/theme';
 
 type HomeScreenNavigationProp = NativeStackNavigationProp<RootStackParamList, 'Home'>;
-
-// カラー定数
-const COLORS = {
-  background: '#F5F5F5',
-  white: '#FFFFFF',
-  text: '#000000',
-  textSecondary: '#666666',
-  error: '#FF3B30',
-};
 
 // フォントサイズ定数
 const FONT_SIZES = {
@@ -61,6 +53,8 @@ export const HomeScreen: React.FC = () => {
     loadEntries,
     getEntryByDate,
   } = useDiaryStore();
+  const theme = useTheme();
+  const styles = createStyles(theme);
 
   useEffect(() => {
     Promise.resolve(loadEntries()).catch(() => {
@@ -151,10 +145,10 @@ export const HomeScreen: React.FC = () => {
   );
 };
 
-const styles = StyleSheet.create({
+const createStyles = (theme: ReturnType<typeof useTheme>) => StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: COLORS.background,
+    backgroundColor: theme.background,
     padding: SPACING.container,
   } as ViewStyle,
   header: {
@@ -166,7 +160,7 @@ const styles = StyleSheet.create({
   title: {
     fontSize: FONT_SIZES.title,
     fontWeight: '600',
-    color: COLORS.text,
+    color: theme.text,
   } as TextStyle,
   section: {
     marginBottom: SPACING.sectionBottom,
@@ -174,24 +168,24 @@ const styles = StyleSheet.create({
   sectionTitle: {
     fontSize: FONT_SIZES.sectionTitle,
     fontWeight: '600',
-    color: COLORS.text,
+    color: theme.text,
     marginBottom: SPACING.sectionTitleBottom,
   } as TextStyle,
   loadingText: {
     fontSize: FONT_SIZES.body,
-    color: COLORS.textSecondary,
+    color: theme.textSecondary,
     textAlign: 'center',
     marginTop: SPACING.emptyTop,
   } as TextStyle,
   errorText: {
     fontSize: FONT_SIZES.body,
-    color: COLORS.error,
+    color: theme.error,
     textAlign: 'center',
     marginTop: SPACING.emptyTop,
   } as TextStyle,
   emptyText: {
     fontSize: FONT_SIZES.caption,
-    color: COLORS.textSecondary,
+    color: theme.textSecondary,
     textAlign: 'center',
     marginTop: SPACING.emptyTop,
   } as TextStyle,

--- a/src/screens/QuestionSettingsScreen.tsx
+++ b/src/screens/QuestionSettingsScreen.tsx
@@ -16,15 +16,7 @@ import {
 } from 'react-native';
 import { useQuestionStore } from '../stores/questionStore';
 import { QuestionType } from '../types';
-
-const COLORS = {
-  background: '#F5F5F5',
-  white: '#FFFFFF',
-  text: '#000000',
-  textSecondary: '#666666',
-  error: '#FF3B30',
-  primary: '#007AFF',
-};
+import { useThemeColors, ThemeColors } from '../theme';
 
 const FONT_SIZES = {
   title: 24,
@@ -46,6 +38,8 @@ const QUESTION_TYPE_LABELS: Record<QuestionType, string> = {
 };
 
 export const QuestionSettingsScreen: React.FC = () => {
+  const theme = useThemeColors();
+  const styles = createStyles(theme);
   const {
     questions,
     loadQuestions,
@@ -90,7 +84,7 @@ export const QuestionSettingsScreen: React.FC = () => {
                 testID={`question-switch-${question.id}`}
                 value={question.isActive}
                 onValueChange={() => toggleQuestionActive(question.id)}
-                trackColor={{ false: '#ccc', true: COLORS.primary }}
+                trackColor={{ false: '#ccc', true: theme.primary }}
               />
               <TouchableOpacity
                 testID={`question-delete-${question.id}`}
@@ -117,26 +111,26 @@ export const QuestionSettingsScreen: React.FC = () => {
   );
 };
 
-const styles = StyleSheet.create({
+const createStyles = (theme: ThemeColors) => StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: COLORS.background,
+    backgroundColor: theme.background,
     padding: SPACING.container,
   } as ViewStyle,
   title: {
     fontSize: FONT_SIZES.title,
     fontWeight: '600',
-    color: COLORS.text,
+    color: theme.text,
     marginBottom: SPACING.titleBottom,
   } as TextStyle,
   emptyText: {
     fontSize: FONT_SIZES.body,
-    color: COLORS.textSecondary,
+    color: theme.textSecondary,
     textAlign: 'center',
     marginTop: 20,
   } as TextStyle,
   questionItem: {
-    backgroundColor: COLORS.white,
+    backgroundColor: theme.cardBackground,
     borderRadius: 8,
     padding: SPACING.container,
     marginBottom: SPACING.itemGap,
@@ -150,12 +144,12 @@ const styles = StyleSheet.create({
   } as ViewStyle,
   questionText: {
     fontSize: FONT_SIZES.body,
-    color: COLORS.text,
+    color: theme.text,
     marginBottom: 4,
   } as TextStyle,
   questionType: {
     fontSize: FONT_SIZES.caption,
-    color: COLORS.textSecondary,
+    color: theme.textSecondary,
   } as TextStyle,
   questionActions: {
     flexDirection: 'row',
@@ -166,23 +160,23 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 6,
     borderRadius: 4,
-    backgroundColor: COLORS.error,
+    backgroundColor: theme.error,
   } as ViewStyle,
   deleteButtonText: {
     fontSize: FONT_SIZES.caption,
-    color: COLORS.white,
+    color: theme.cardBackground,
     fontWeight: '600',
   } as TextStyle,
   resetButton: {
     marginTop: SPACING.container,
     padding: SPACING.container,
     borderRadius: 8,
-    backgroundColor: COLORS.white,
+    backgroundColor: theme.cardBackground,
     alignItems: 'center',
   } as ViewStyle,
   resetButtonText: {
     fontSize: FONT_SIZES.body,
-    color: COLORS.primary,
+    color: theme.primary,
     fontWeight: '600',
   } as TextStyle,
 });

--- a/src/screens/ReminderSettingsScreen.tsx
+++ b/src/screens/ReminderSettingsScreen.tsx
@@ -15,15 +15,7 @@ import {
 } from 'react-native';
 import { useSettingsStore } from '../stores/settingsStore';
 import { ReminderTime } from '../types';
-
-const COLORS = {
-  background: '#F5F5F5',
-  white: '#FFFFFF',
-  text: '#000000',
-  textSecondary: '#666666',
-  error: '#FF3B30',
-  primary: '#007AFF',
-};
+import { useThemeColors, ThemeColors } from '../theme';
 
 const FONT_SIZES = { title: 24, body: 16, caption: 14 };
 const SPACING = { container: 16, titleBottom: 24, itemGap: 12 };
@@ -39,6 +31,8 @@ const formatTime = (hour: number, minute: number): string => {
 };
 
 export const ReminderSettingsScreen: React.FC = () => {
+  const theme = useThemeColors();
+  const styles = createStyles(theme);
   const {
     settings,
     loadSettings,
@@ -111,21 +105,21 @@ export const ReminderSettingsScreen: React.FC = () => {
   );
 };
 
-const styles = StyleSheet.create({
+const createStyles = (theme: ThemeColors) => StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: COLORS.background,
+    backgroundColor: theme.background,
     padding: SPACING.container,
   } as ViewStyle,
   title: {
     fontSize: FONT_SIZES.title,
     fontWeight: '600',
-    color: COLORS.text,
+    color: theme.text,
     marginBottom: SPACING.titleBottom,
   } as TextStyle,
   emptyText: {
     fontSize: FONT_SIZES.body,
-    color: COLORS.textSecondary,
+    color: theme.textSecondary,
     textAlign: 'center',
     marginTop: 20,
   } as TextStyle,
@@ -133,7 +127,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-    backgroundColor: COLORS.white,
+    backgroundColor: theme.cardBackground,
     padding: SPACING.container,
     borderRadius: 8,
     marginBottom: SPACING.itemGap,
@@ -141,7 +135,7 @@ const styles = StyleSheet.create({
   timeText: {
     fontSize: FONT_SIZES.body,
     fontWeight: '600',
-    color: COLORS.text,
+    color: theme.text,
   } as TextStyle,
   itemActions: {
     flexDirection: 'row',
@@ -154,10 +148,10 @@ const styles = StyleSheet.create({
   } as ViewStyle,
   deleteText: {
     fontSize: FONT_SIZES.caption,
-    color: COLORS.error,
+    color: theme.error,
   } as TextStyle,
   addButton: {
-    backgroundColor: COLORS.primary,
+    backgroundColor: theme.primary,
     padding: SPACING.container,
     borderRadius: 8,
     alignItems: 'center',
@@ -166,6 +160,6 @@ const styles = StyleSheet.create({
   addButtonText: {
     fontSize: FONT_SIZES.body,
     fontWeight: '600',
-    color: COLORS.white,
+    color: theme.cardBackground,
   } as TextStyle,
 });

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -21,12 +21,7 @@ import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { ListItem } from '../components/ListItem';
 import type { RootStackParamList } from '../types/navigation';
-
-// カラー定数
-const COLORS = {
-  background: '#F5F5F5',
-  text: '#000000',
-};
+import { useTheme } from '../utils/theme';
 
 // フォントサイズ定数
 const FONT_SIZES = {
@@ -50,6 +45,8 @@ type SettingsNavigationProp = NativeStackNavigationProp<RootStackParamList, 'Set
 
 export const SettingsScreen: React.FC = () => {
   const navigation = useNavigation<SettingsNavigationProp>();
+  const theme = useTheme();
+  const styles = createStyles(theme);
 
   const handleNavigate = (screen: SettingScreen) => {
     try {
@@ -103,10 +100,10 @@ export const SettingsScreen: React.FC = () => {
   );
 };
 
-const styles = StyleSheet.create({
+const createStyles = (theme: ReturnType<typeof useTheme>) => StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: COLORS.background,
+    backgroundColor: theme.background,
   } as ViewStyle,
   contentContainer: {
     padding: SPACING.container,
@@ -114,7 +111,7 @@ const styles = StyleSheet.create({
   title: {
     fontSize: FONT_SIZES.title,
     fontWeight: '600',
-    color: COLORS.text,
+    color: theme.text,
     marginBottom: SPACING.titleBottom,
   } as TextStyle,
 });

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -21,7 +21,7 @@ import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { ListItem } from '../components/ListItem';
 import type { RootStackParamList } from '../types/navigation';
-import { useTheme } from '../utils/theme';
+import { useThemeColors, ThemeColors } from '../theme';
 
 // フォントサイズ定数
 const FONT_SIZES = {
@@ -45,7 +45,7 @@ type SettingsNavigationProp = NativeStackNavigationProp<RootStackParamList, 'Set
 
 export const SettingsScreen: React.FC = () => {
   const navigation = useNavigation<SettingsNavigationProp>();
-  const theme = useTheme();
+  const theme = useThemeColors();
   const styles = createStyles(theme);
 
   const handleNavigate = (screen: SettingScreen) => {
@@ -100,7 +100,7 @@ export const SettingsScreen: React.FC = () => {
   );
 };
 
-const createStyles = (theme: ReturnType<typeof useTheme>) => StyleSheet.create({
+const createStyles = (theme: ThemeColors) => StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: theme.background,

--- a/src/theme/ThemeContext.tsx
+++ b/src/theme/ThemeContext.tsx
@@ -1,0 +1,59 @@
+/**
+ * テーマコンテキスト
+ * アプリ全体でテーマを共有するためのContext + Provider
+ */
+import React, { createContext, useContext, useMemo } from 'react';
+import { ThemeColors, LIGHT_THEME, DARK_THEME } from './colors';
+import { useSettingsStore } from '../stores/settingsStore';
+
+// テーマコンテキストの型
+interface ThemeContextValue {
+  theme: ThemeColors;
+  isDarkMode: boolean;
+}
+
+// デフォルト値
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: LIGHT_THEME,
+  isDarkMode: false,
+});
+
+/**
+ * テーマプロバイダー
+ * アプリのルートで使用し、全コンポーネントにテーマを提供する
+ */
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const settings = useSettingsStore((state) => state.settings);
+  const isDarkMode = settings.isDarkMode;
+
+  const value = useMemo(
+    () => ({
+      theme: isDarkMode ? DARK_THEME : LIGHT_THEME,
+      isDarkMode,
+    }),
+    [isDarkMode]
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+/**
+ * テーマを使用するためのフック
+ * どのコンポーネントからでもテーマ情報にアクセス可能
+ */
+export const useTheme = (): ThemeContextValue => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};
+
+/**
+ * テーマ色のみを取得するフック
+ * スタイリング用にテーマ色のみが必要な場合に使用
+ */
+export const useThemeColors = (): ThemeColors => {
+  const { theme } = useTheme();
+  return theme;
+};

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -1,43 +1,61 @@
 /**
- * テーマ設定
- * ダークモード/Lightモードの配色を管理
+ * テーマ色の定義
+ * ライトモードとダークモードの配色セット
  */
-import { useSettingsStore } from '../stores/settingsStore';
 
 export interface ThemeColors {
+  // 背景色
   background: string;
   cardBackground: string;
+
+  // テキスト色
   text: string;
   textSecondary: string;
+
+  // UI要素
   border: string;
   primary: string;
   error: string;
+
+  // 追加色
+  white: string;
+  selected: string;
 }
 
 export const LIGHT_THEME: ThemeColors = {
+  // 背景色
   background: '#F5F5F5',
   cardBackground: '#FFFFFF',
+
+  // テキスト色
   text: '#000000',
   textSecondary: '#666666',
+
+  // UI要素
   border: '#E0E0E0',
   primary: '#007AFF',
   error: '#FF3B30',
+
+  // 追加色
+  white: '#FFFFFF',
+  selected: '#E3F2FD',
 };
 
 export const DARK_THEME: ThemeColors = {
+  // 背景色
   background: '#1A1A1A',
   cardBackground: '#2A2A2A',
+
+  // テキスト色
   text: '#FFFFFF',
   textSecondary: '#AAAAAA',
+
+  // UI要素
   border: '#3A3A3A',
   primary: '#0A84FF',
   error: '#FF453A',
-};
 
-/**
- * 現在のテーマ色を取得するフック
- */
-export const useTheme = (): ThemeColors => {
-  const settings = useSettingsStore((state) => state.settings);
-  return settings.isDarkMode ? DARK_THEME : LIGHT_THEME;
+  // 追加色
+  white: '#1A1A1A',
+  selected: '#1E3A5F',
 };

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,7 @@
+/**
+ * テーマモジュール
+ * テーマ関連の全てのエクスポートをまとめる
+ */
+export { ThemeProvider, useTheme, useThemeColors } from './ThemeContext';
+export { LIGHT_THEME, DARK_THEME } from './colors';
+export type { ThemeColors } from './colors';

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -38,6 +38,6 @@ export const DARK_THEME: ThemeColors = {
  * 現在のテーマ色を取得するフック
  */
 export const useTheme = (): ThemeColors => {
-  const isDarkMode = useSettingsStore((state) => state.settings.isDarkMode);
-  return isDarkMode ? DARK_THEME : LIGHT_THEME;
+  const settings = useSettingsStore((state) => state.settings);
+  return settings.isDarkMode ? DARK_THEME : LIGHT_THEME;
 };


### PR DESCRIPTION
## Summary
ユーザー報告: 設定画面でしかダークモードが効かない → ThemeProviderパターンで再設計

## 新しいアーキテクチャ

```
App.tsx
  └── ThemeProvider  ← テーマを一元管理
        └── AppNavigator
              └── 各画面コンポーネント
                    └── useThemeColors() でテーマ色を取得
```

### ファイル構成
| ファイル | 役割 |
|---------|------|
| `src/theme/ThemeContext.tsx` | Context + Provider + useTheme/useThemeColors |
| `src/theme/colors.ts` | LIGHT_THEME / DARK_THEME 定義 |
| `src/theme/index.ts` | エクスポートまとめ |

## 更新された画面（8画面全て）
- ✅ HomeScreen, SettingsScreen, DisplaySettingsScreen
- ✅ DiaryInputScreen, DiaryDetailScreen
- ✅ DataManagementScreen, QuestionSettingsScreen, ReminderSettingsScreen

## テスト
- [x] `npm test` — 468 tests passed
- [x] `npx tsc --noEmit` — TypeScript clean

## 期待動作
設定画面でダークモードをON → **即座に全画面**の配色が変わる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# リリースノート

* **新機能**
  * アプリ全体でテーマ対応（ライト/ダーク）を導入し、設定に応じたカラースキームが適用されます
  * ステータスバーやボタン、入力欄など多数のコンポーネントがテーマに応じて表示されます
  * TextInputのアクセシビリティが改善されました

* **Style / リファクタ**
  * 各画面・コンポーネントのスタイルを統一し、動的テーマに対応するよう更新しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->